### PR TITLE
Fixed the Debug process and files errors

### DIFF
--- a/extension/.vscode/launch.json
+++ b/extension/.vscode/launch.json
@@ -14,7 +14,7 @@
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": [
-        "${workspaceFolder}/out/**/*.js"
+        "${workspaceFolder}/dist/**/*.js"
       ],
       "preLaunchTask": "npm: watch"
     },
@@ -24,13 +24,14 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
+        "${workspaceFolder}/out/tests/workspace",
         "--extensionDevelopmentPath=${workspaceFolder}",
-        "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+        "--extensionTestsPath=${workspaceFolder}/out/tests/suite/index"
       ],
       "outFiles": [
-        "${workspaceFolder}/out/test/**/*.js"
+        "${workspaceFolder}/out/tests/**/*.js"
       ],
-      "preLaunchTask": "npm: watch"
+      "preLaunchTask": "npm: test-watch"
     }
   ]
 }

--- a/extension/.vscode/tasks.json
+++ b/extension/.vscode/tasks.json
@@ -5,16 +5,58 @@
   "tasks": [
     {
       "type": "npm",
-      "script": "watch",
-      "problemMatcher": "$tsc-watch",
-      "isBackground": true,
-      "presentation": {
-        "reveal": "never"
-      },
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      }
-    }
+			"script": "watch",
+			"problemMatcher": [
+        // problemMatcher based on the https://github.com/eamodio/vscode-tsl-problem-matcher problem matchers
+        // updated to include a beginsPattern that works with webpack v5.11+
+        {
+          "owner": "typescript",
+          "source": "ts",
+          "fileLocation": "absolute",
+          "severity": "error",
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": {
+              "regexp": "Compiling.*?|Compilation .*?starting|\\d+% building.*|asset.*?"
+            },
+            "endsPattern": {
+              "regexp": "[Cc]ompiled (.*?successfully|with .*?(errors|warnings))|[Cc]ompilation .*?finised"
+            }
+          },
+          "pattern": [
+            {
+              "regexp": "\\[tsl\\] ERROR in (.*)?\\((\\d+),(\\d+)\\)",
+              "severity": 1,
+              "file": 2,
+              "line": 3,
+              "column": 4
+            },
+            {
+              "regexp": "\\s*TS(\\d+):\\s*(.*)$",
+              "code": 1,
+              "message": 2
+            }
+          ]
+        }
+			],
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"type": "npm",
+			"script": "test-watch",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": "build"
+		}
   ]
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -78,14 +78,15 @@
     }
   },
   "scripts": {
-    "package": "npx vsce package -o release.vsix",
-    "vscode:prepublish": "webpack --mode production",
-    "compile": "tsc -p ./ && webpack",
-    "lint": "eslint --ext .ts .",
-    "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile",
-    "webpack": "webpack --mode production",
-    "test": "node ./out/tests/runTest.js"
+    "vscode:prepublish": "npm run package",
+    "compile": "webpack",
+    "watch": "webpack --watch --progress",
+    "package": "webpack --mode production --devtool hidden-source-map",
+    "test-compile": "tsc -p ./",
+    "test-watch": "tsc -watch -p ./",
+    "pretest": "npm run test-compile && npm run lint",
+    "lint": "eslint src --ext ts",
+    "test": "node ./out/test/runTest.js"
   },
   "dependencies": {
     "node-fetch": "^2.6.1",

--- a/extension/src/telemetry.ts
+++ b/extension/src/telemetry.ts
@@ -174,7 +174,7 @@ export class GoogleAnalyticsTelemetry implements Telemetry {
       .getConfiguration('telemetry')
       .get('enableTelemetry', false);
     const onlyThemesEnableTelemetry = vscode.workspace
-      .getConfiguration('onlyThemes.telemetry')
+      .getConfiguration('onlythemes.telemetry')
       .get('enabled', false);
     return enableTelemetry && onlyThemesEnableTelemetry;
   }

--- a/extension/src/utils/getExtenionInfo.ts
+++ b/extension/src/utils/getExtenionInfo.ts
@@ -4,7 +4,7 @@ import { extensions } from 'vscode';
  * Returns the package.json contents for the Vonage extension.
  */
 export function getExtensionInfo(): any {
-  const extension = extensions.getExtension('vonage.vscode');
+  const extension = extensions.getExtension('michaeljolley.onlythemes');
   if (extension) {
     return extension.packageJSON;
   }

--- a/extension/tests/suite/extension.test.ts
+++ b/extension/tests/suite/extension.test.ts
@@ -2,8 +2,8 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 
 suite('Extension', () => {
-	test('Should start extension vonage.vscode', async () => {
-		const started = vscode.extensions.getExtension('vonage.vscode');
+	test('Should start extension michaeljolley.onlythemes', async () => {
+		const started = vscode.extensions.getExtension('michaeljolley.onlythemes');
 		assert.notStrictEqual(started, undefined);
 		if (started) {
 			await started.activate();

--- a/extension/tests/suite/telemetry.test.ts
+++ b/extension/tests/suite/telemetry.test.ts
@@ -11,7 +11,7 @@ suite('Telemetry', function () {
       vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0];
     const telemetryConfig = vscode.workspace.getConfiguration('telemetry', workspaceFolder);
     const onlyThemesTelemetryConfig = vscode.workspace.getConfiguration(
-      'onlyThemes.telemetry',
+      'onlythemes.telemetry',
       workspaceFolder,
     );
 

--- a/extension/tests/suite/utils/getExtensionInfo.test.ts
+++ b/extension/tests/suite/utils/getExtensionInfo.test.ts
@@ -3,10 +3,10 @@ import * as assert from 'assert';
 import * as utils from '../../../src/utils';
 
 suite('Utils:getExtensionInfo', () => {
-  test('Returns vonage.vscode extension', async () => {
+  test('Returns michaeljolley.onlythemes extension', async () => {
     const extensionInfo = utils.getExtensionInfo();
 
     assert.notDeepStrictEqual(extensionInfo, {});
-    assert.strictEqual(<vscode.Extension<any>>extensionInfo.id, 'vonage.vscode');
+    assert.strictEqual(<vscode.Extension<any>>extensionInfo.id, 'michaeljolley.onlythemes');
   });
 });

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -6,6 +6,7 @@ const path = require('path');
 /**@type {import('webpack').Configuration}*/
 const config = {
   target: 'node', // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
+	mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
 
   entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {
@@ -15,7 +16,7 @@ const config = {
     libraryTarget: 'commonjs2',
     devtoolModuleFilenameTemplate: '../[resource-path]'
   },
-  devtool: 'source-map',
+  devtool: 'nosources-source-map',
   externals: {
     vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
   },


### PR DESCRIPTION
During the VS Code extensions development, there are two build tools at play: `tsc` and `webpack`.

For extension debugging, VS Code needs to use the `webpack` output which goes to the `dist` folder. For test debugging, VS Code needs to use the `tsc` output which goes to the `out` folder.

I updated the various `npm scripts` to allow us to debug in both these scenarios:

- `npm watch` will now launch `webpack watch --progress` which will watch for file changes and repackage our files using webpack into the `dist` folder.
- `npm test-watch` will now launch `tsc -watch -p ./` which will watch for file changes and transpile our files using tsc into the `out` folder.

Additionally, in order to get the tests to pass I updated files which still had reminents pointing to another extension we copied assets from. All tests are now successful!