### PR TITLE
fix(WebView): Guarantee WCAG AAA color contrast ratios

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -990,6 +990,11 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "color2k": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-1.2.4.tgz",
+      "integrity": "sha512-DiwdBwc0BryPFFXoCrW8XQGXl2rEtMToODybxZjKnN5IJXt/tV/FsN02pCK/b7KcWvJEioz3c74lQSmayFvS4Q=="
+    },
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",

--- a/extension/package.json
+++ b/extension/package.json
@@ -88,6 +88,7 @@
     "test": "node ./out/tests/runTest.js"
   },
   "dependencies": {
+    "color2k": "^1.2.4",
     "node-fetch": "^2.6.1",
     "os-name": "^4.0.0",
     "public-ip": "^4.0.3",


### PR DESCRIPTION
With this, we are fixing the webview to guarantee that the color
contrast is following the WCAG AAA standard.
(https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)