### PR TITLE
feat: implement "Forget My Ratings" command. Closes #31

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -42,6 +42,12 @@ Maybe this is the theme you've been dreaming of! Click the "thumbs up" icon
 to let us know you like it. We'll even offer to install the theme and activate
 it for you.
 
+### 🔥 I want to start over
+
+If you'd like to just start completely over so that all of your previous ratings
+are thrown out, try using the Command Palette (Cmd + Shift + P), and choose "Forget My Ratings".
+This will confirm you want to do it, and will start you from scratch.
+
 ### 💻 How does it work?
 
 Want to see the code? Click the Bald Bearded Builder logo to see the repo. We

--- a/extension/package.json
+++ b/extension/package.json
@@ -56,7 +56,8 @@
     "commands": [
       {
         "command":"onlythemes.forgetMe",
-        "title":"Forget My Ratings"
+        "title":"Forget My Ratings",
+        "category":"OnlyThemes"
       }
     ],
     "views": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -38,7 +38,8 @@
   ],
   "activationEvents": [
     "onView:onlyThemesView",
-    "onView:thumbnailView"
+    "onView:thumbnailView",
+    "onCommand:onlythemes.forgetMe"
   ],
   "contributes": {
     "configuration": {
@@ -52,7 +53,12 @@
         }
       }
     },
-    "commands": [],
+    "commands": [
+      {
+        "command":"onlythemes.forgetMe",
+        "title":"Forget My Ratings"
+      }
+    ],
     "views": {
       "onlyThemes": [
         {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -34,6 +34,19 @@ export class Extension {
 
     _context.subscriptions.push(
       vscode.window.registerWebviewViewProvider(OnlyThemesViewProvider.viewType, onlyThemesViewProvider));
+    _context.subscriptions.push(
+      vscode.commands.registerCommand("onlythemes.forgetMe", async () => {
+        const forgetMeSelection = 'Yes';
+        const prompts = [forgetMeSelection, 'No'];
+
+        const selection = await vscode.window.showInformationMessage(
+          "This will reset all of your OnlyThemes ratings, but it will not affect any of your installed extensions. Are you sure you want to do this?",
+          ...prompts
+        );
+        if(selection == forgetMeSelection){
+          Settings.resetUser();
+        }
+      }));
   }
 
   /**

--- a/extension/src/settings.ts
+++ b/extension/src/settings.ts
@@ -21,4 +21,9 @@ export class Settings {
   public static async getUser(): Promise<string | null | undefined> {
     return await this.storage.get(SettingKeys.userId);
   }
+  
+  public static async resetUser(): Promise<void> {
+    const newUserId = v4();
+    await this.storage.update(SettingKeys.userId, newUserId);
+  }
 }


### PR DESCRIPTION
This should fix #31. Per @MichaelJolley this should be a command palette option. 

Of course I've never done this before so I tried to follow along with [a VS Code extension commands guide](https://code.visualstudio.com/api/extension-guides/command). 

Screenshots below (last of which is a console.log that I removed before pushing).

![Screen Shot 2021-05-08 at 3 18 36 PM](https://user-images.githubusercontent.com/3792749/117551098-ef42d800-b011-11eb-92b0-3cac61361020.png)
![Screen Shot 2021-05-08 at 3 21 29 PM](https://user-images.githubusercontent.com/3792749/117551103-f36ef580-b011-11eb-9638-d03e37e5d8d5.png)
![Screen Shot 2021-05-08 at 3 22 29 PM](https://user-images.githubusercontent.com/3792749/117551105-f833a980-b011-11eb-978c-6169eb7d6bc9.png)


